### PR TITLE
Initial build for 0.3.1.2 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "types-pyfarmhash" %}
-{% set version = "0.3.1.1" %}
-
+{% set version = "0.3.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,32 +7,42 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/types-pyfarmhash-{{ version }}.tar.gz
-  sha256: 2777d4619ca214313a29cfa273dde62ecb5e96b5f1b491b3d0d4549e21f6ffd0
+  sha256: beca9c1d1bd2f0c22991337c94f0b624cd3375349dd3e64db8d50aa54adb22ea
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
+  requires:
+    - pip
   commands:
     - test -f $SP_DIR/farmhash-stubs/__init__.pyi
+    - pip check
 
 
 about:
   home: https://github.com/python/typeshed
   summary: Typing stubs for pyfarmhash
+  description: Typing stubs for pyfarmhash
   license: Apache-2.0 AND MIT
+  license_family: OTHER
   license_file: LICENSE
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://github.com/python/typeshed
 
 extra:
   recipe-maintainers:
     - fhoehle
     - conda-forge/mypy
+  skip-lints:
+    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ test:
   requires:
     - pip
   commands:
-    - test -f $SP_DIR/farmhash-stubs/__init__.pyi
+    - test -f $SP_DIR/farmhash-stubs/__init__.pyi  # [not win]
+    - if not exist %SP_DIR%\\farmhash-stubs\\__init__.pyi exit 1  # [win]
     - pip check
-
 
 about:
   home: https://github.com/python/typeshed


### PR DESCRIPTION
types-pyfarmhash 0.3.1.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3781](https://anaconda.atlassian.net/browse/PKG-3781)
- [Upstream repository](https://github.com/python/typeshed/tree/main/stubs/pyfarmhash)



[PKG-3781]: https://anaconda.atlassian.net/browse/PKG-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ